### PR TITLE
ToFの修正

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,11 +275,7 @@ void setup()
   Serial2.begin(115200, SERIAL_8N1, RXp2, TXp2);
   while(!Serial2); //wait untill it opens
   Wire.begin();
-
-  // MultiThread ------------------------------------------------------------
-  xTaskCreatePinnedToCore(UART, "UART", 4096, NULL, 3, &thp[0], 0); 
-  xTaskCreatePinnedToCore(BNO055, "BNO055", 4096, NULL, 5, &thp[1], 0);
-  xTaskCreatePinnedToCore(line_sensors,"line_sensors",4096,NULL,2,&thp[2],0);
+  
   // BNO055 ------------------------------------------------------------
   Wire1.begin(Wire1_SDA, Wire1_SCL);
   /* Initialise the sensor */
@@ -359,6 +355,11 @@ void setup()
 
   // start
   VL53L0X[1].startContinuous(10);
+  
+  // MultiThread ------------------------------------------------------------
+  xTaskCreatePinnedToCore(UART, "UART", 4096, NULL, 3, &thp[0], 0); 
+  xTaskCreatePinnedToCore(BNO055, "BNO055", 4096, NULL, 5, &thp[1], 0);
+  xTaskCreatePinnedToCore(line_sensors,"line_sensors",4096,NULL,2,&thp[2],0);
   
   // ------------------------------------------------------------
   Serial.println("start");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,6 +214,12 @@ void BNO055(void *args) {
     } else {
       gyro_stats = 0;
     }
+    float z_hill = (float)event.orientation.z;
+    if (z_hill >= 3){
+      gyro_stats += 10;
+    } else if (z_hill <= -3){
+      gyro_stats += 20;
+    }
     gyro_x = (uint8_t)(event.orientation.x / 2);
 
     delay(BNO055_SAMPLERATE_DELAY_MS);


### PR DESCRIPTION
ToFがRTOSのタスク内で動かず、loop()内では動いた原因はxTaskCreateの後に設定をしていたためだと思われる。  
少なくとも[Teensy4.1の環境](https://github.com/tsandmann/freertos-teensy)ではそれで修正できた。  
実際にESP32で走らせたわけではない。
